### PR TITLE
[fix] recipe ui ingredient Images

### DIFF
--- a/Assets/UI/JJY/Scripts/RecipeUI.cs
+++ b/Assets/UI/JJY/Scripts/RecipeUI.cs
@@ -22,22 +22,22 @@ namespace JJY
         public int uniqueID;
 
         // 외부에서 레시피 데이터 받아 UI 설정
-        public void Setup(RecipeData recipe, int id)
+        public void Setup(RecipeData recipeData, int id)
         {
-            curRecipe = recipe;
+            curRecipe = recipeData;
             uniqueID = id;
 
-            outputImage.sprite = recipe.outputImage;
-            recipeNameText.text = recipe.recipeName;
+            outputImage.sprite = recipeData.outputImage;
+            recipeNameText.text = recipeData.recipeName;
 
             // ingredientImages는 고정된 슬롯이고,
             // 실제 레시피에 따라 일부만 활성화하거나 끔
             for (int i = 0; i < ingredientImages.Count; i++)
             {
-                if (i < recipe.ingredientImages.Count)
+                if (i < recipeData.ingredientImages.Count)
                 {
-                    ingredientImages[i].sprite = recipe.ingredientImages[i];
                     ingredientImages[i].enabled = true;
+                    ingredientImages[i].sprite = recipeData.ingredientImages[i];
                 }
                 else
                 {


### PR DESCRIPTION
- 레시피 ui에 표시될 text, 완성품 이미지는 S/O에서 받아온 정보로 동기회가 되지만, 재료들의 이미지들은 동기화되지 않았음.

## 🧩 개요
- 이번 PR에서 변경된 핵심 내용을 간단히 적어주세요.
- 관련 이슈: Close #

## 📁 변경 사항 체크리스트

- [x] C# 스크립트 추가/수정
- [ ] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [ ] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항

- [ ] Unity 에디터에서 정상 동작 확인
- [ ] 관련 기능 플레이 테스트 완료
- [ ] 에러/경고 없음
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [ ] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역

- [ ] 새 기능 직접 실행 확인
- [ ] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [ ] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
