### PR TITLE
Fix 프리펩 수정 및 코드 수정

### DIFF
--- a/Assets/Player/SCR/Scripts/RoomManager.cs
+++ b/Assets/Player/SCR/Scripts/RoomManager.cs
@@ -22,8 +22,8 @@ namespace SCR
         public void StartGame()
         {
             ExitGames.Client.Photon.Hashtable playerProperty = new();
-            playerProperty["Character"] = characterToggle.SelectIndex;
-            playerProperty["Team"] = teamToggle.SelectIndex;
+            playerProperty[MIN.CustomPropertyKeys.CharacterId] = characterToggle.SelectIndex;
+            playerProperty[MIN.CustomPropertyKeys.TeamColor] = teamToggle.SelectIndex;
             PhotonNetwork.LocalPlayer.SetCustomProperties(playerProperty);
             Debug.Log("게임 시작");
             PhotonNetwork.LoadLevel("TestGameScene");

--- a/Assets/Resources/MatItem.prefab
+++ b/Assets/Resources/MatItem.prefab
@@ -113,7 +113,7 @@ Rigidbody:
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
   m_UseGravity: 1
-  m_IsKinematic: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 80
   m_CollisionDetection: 0

--- a/Assets/Resources/Player.prefab
+++ b/Assets/Resources/Player.prefab
@@ -47,7 +47,6 @@ GameObject:
   - component: {fileID: 526741903923922752}
   - component: {fileID: 6069788371936208484}
   - component: {fileID: 457358773405712941}
-  - component: {fileID: 2489011030158492331}
   m_Layer: 3
   m_Name: LeftHand
   m_TagString: Untagged
@@ -121,27 +120,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &2489011030158492331
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2922689207003343476}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &3564845211051021667
 GameObject:
   m_ObjectHideFlags: 0
@@ -302,7 +280,6 @@ GameObject:
   - component: {fileID: 2782908737179183046}
   - component: {fileID: 3984459912922955151}
   - component: {fileID: 8270581295171932951}
-  - component: {fileID: 3656412699913113127}
   m_Layer: 3
   m_Name: RightHand
   m_TagString: Untagged
@@ -376,27 +353,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &3656412699913113127
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8631212587677857607}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8865999002279360037
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 🧩 개요
- 플레이어,  MatItem 프리펩 변경
- RoomManager 프로퍼티를 string 대신 CustomPropertyKeys를 사용하여 생성

## 📁 변경 사항 체크리스트

- [x] C# 스크립트 추가/수정
- [x] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [ ] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항

- [x] Unity 에디터에서 정상 동작 확인
- [x] 관련 기능 플레이 테스트 완료
- [x] 에러/경고 없음
- [x] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [x] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역

- [x] 새 기능 직접 실행 확인
- [x] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [x] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
