### PR TITLE
[fix] Recipe UI Create

### DIFF
--- a/Assets/UI/SCR/OrderUI.cs
+++ b/Assets/UI/SCR/OrderUI.cs
@@ -20,6 +20,8 @@ namespace SCR
         [SerializeField] private ProductSprites productSprites; // 딕셔너리, 완성품 이미지들
         [Inject] IScoreManager _scoreManager;
 
+        private Coroutine orderRoutine; // 코루틴 중복 방지를 위해 추가.
+
         private int targetIndex = -1;
 
         private void Start()
@@ -30,7 +32,8 @@ namespace SCR
         public void StartOrder()
         {
             if (!PhotonNetwork.IsMasterClient) return;
-            StartCoroutine(OrderCoroutine());
+            if (orderRoutine != null) return;
+            orderRoutine = StartCoroutine(OrderCoroutine()); // 게임 종료시, 멈춰주어야 함.
         }
 
         private IEnumerator OrderCoroutine()
@@ -51,13 +54,10 @@ namespace SCR
                 if (!CheckFullOrder())
                     AddRecipe();
             }
-
         }
 
         public void AddRecipe() // 특정 시간마다 호출 또는 다 껴져있을 때 호출
         {
-            // if (!PhotonNetwork.IsMasterClient) return;
-
             //int index = Random.Range(0, allRecipes.Count);
             int prod = UnityEngine.Random.Range(0, itemDataList.craftList.Count);
             int ore = UnityEngine.Random.Range(1, materialData.ores.Count);


### PR DESCRIPTION
- 인원수에 따라 증식되어 소환된 레시피 버그 수정

## 🧩 개요
- 이번 PR에서 변경된 핵심 내용을 간단히 적어주세요.
- 레시피 UI가 인원수에 따라 증식됨 ( 코루틴이 여러번 호출됨 ) 버그 수정

## 📁 변경 사항 체크리스트

- [x] C# 스크립트 추가/수정
- [ ] 프리팹 변경
- [ ] 씬(.unity) 파일 변경
- [ ] 애니메이션/사운드 리소스 변경
- [ ] ScriptableObject 변경
- [ ] 기타 리소스 또는 설정 변경

## ✅ 확인 사항

- [x] Unity 에디터에서 정상 동작 확인
- [x] 관련 기능 플레이 테스트 완료
- [x] 에러/경고 없음
- [ ] 변경된 파일이 Git LFS 대상인지 확인 (필요시)
- [ ] 충돌 방지를 위해 최신 develop/main 브랜치에서 작업

## 🧪 테스트 내역

- [ ] 새 기능 직접 실행 확인
- [ ] 씬 변경 시, 기존 오브젝트와 충돌 없음
- [ ] 멀티플레이/네트워크 관련 기능 확인 (해당 시)
- [ ] (선택) 커스텀 유닛/에디터 테스트 포함

## 📝 기타
